### PR TITLE
Add SSH agent for Linux

### DIFF
--- a/script/install
+++ b/script/install
@@ -42,6 +42,7 @@ then
 
     sudo apt install zsh git -y
     sudo apt-get install fasd -y
+    sudo apt-get install keychain -y
 fi
 
 # find the installers and run them iteratively

--- a/zsh/zshrc.symlink
+++ b/zsh/zshrc.symlink
@@ -62,3 +62,10 @@ eval "$(fasd --init auto)"
 # Disable autocorrect
 # https://coderwall.com/p/jaoypq/disabling-autocorrect-in-zsh
 unsetopt correct
+
+# Enable keychain for Linux
+if [ $(uname -s) == "Linux" ]
+then
+  /usr/bin/keychain -q --nogui $HOME/.ssh/id_ed25519
+  source $HOME/.keychain/$HOST-sh
+fi


### PR DESCRIPTION
- Install keychain on Linux
- Use ssh key automatically via `.zshrc`