### PR TITLE
fix: remove path to node modules

### DIFF
--- a/nvm/path.zsh
+++ b/nvm/path.zsh
@@ -1,2 +1,1 @@
 export NVM_DIR="$HOME/.nvm"
-export PATH="./node_modules/.bin:$PATH"


### PR DESCRIPTION
Adding a path to `./node_modules/bin` allowed me to use `npm` modules but hid issues that occur with the rest of the team. Removing and looking to use `npx` instead.